### PR TITLE
Add punctuation option to greet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 This repository demonstrates minimal CI tasks for Codex.
 
+The ``greet`` function now supports custom punctuation via the ``punctuation``
+parameter, allowing more expressive salutations.
+
 ## What is AI?
 Artificial Intelligence (AI) refers to computer systems designed to perform tasks that typically require human intelligence.

--- a/main.py
+++ b/main.py
@@ -1,9 +1,17 @@
 """Simple greeting module."""
 
 
-def greet(name: str = "AI-rt") -> str:
-    """Return a friendly greeting."""
-    return f"Hello, {name}!"
+def greet(name: str = "AI-rt", punctuation: str = "!") -> str:
+    """Return a friendly greeting.
+
+    Parameters
+    ----------
+    name:
+        Name to greet. Defaults to ``"AI-rt"``.
+    punctuation:
+        Ending punctuation for the greeting. Defaults to ``"!"``.
+    """
+    return f"Hello, {name}{punctuation}"
 
 
 def greet_frank() -> str:

--- a/test_main.py
+++ b/test_main.py
@@ -9,5 +9,9 @@ def test_greet_custom():
     assert greet("Codex") == "Hello, Codex!"
 
 
+def test_greet_custom_punctuation():
+    assert greet("Codex", punctuation="?") == "Hello, Codex?"
+
+
 def test_greet_frank():
     assert greet_frank() == "Hello, Frank!"


### PR DESCRIPTION
## Summary
- extend `greet` with optional `punctuation` parameter
- document the new option in README
- test custom punctuation handling

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881d056bfc0832d85ea41170b43da45